### PR TITLE
center messages title when sidebar open

### DIFF
--- a/src/css/messages.css
+++ b/src/css/messages.css
@@ -1,3 +1,7 @@
+#sidebar-toggle[open="true"] + #messages {
+  width: calc(100% - 280px);
+}
+
 #messages {
   display: grid;
   grid-template-rows: auto 1fr;


### PR DESCRIPTION
Apply a negative width to offset the the `translateX`

This works well on Desktop, I wasn't able to test it on Mobile, which might break with this change.

Maybe there's a cleaner way of achieving the same result?

before:
<img width="720" alt="Screenshot 2024-07-01 at 16 39 51" src="https://github.com/socketsupply/kaat/assets/738069/9798f6b6-c8fb-48b0-849a-0c1a8aa76723">

after:
<img width="713" alt="Screenshot 2024-07-01 at 16 40 31" src="https://github.com/socketsupply/kaat/assets/738069/d7c1fc94-244d-4d6b-ad74-085527e54550">
